### PR TITLE
CO-1031 - Update the Engine to get Team data from Ref Data

### DIFF
--- a/src/main/java/uk/gov/homeoffice/borders/workflow/PlatformDataUrlBuilder.java
+++ b/src/main/java/uk/gov/homeoffice/borders/workflow/PlatformDataUrlBuilder.java
@@ -2,18 +2,13 @@ package uk.gov.homeoffice.borders.workflow;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.web.util.UriUtils;
 import uk.gov.homeoffice.borders.workflow.config.PlatformDataBean;
-import uk.gov.homeoffice.borders.workflow.identity.TeamQuery;
 
 import java.nio.charset.StandardCharsets;
 import java.util.*;
-import java.util.stream.Collectors;
-
-import static java.util.Optional.ofNullable;
 
 /**
  * Central place for building urls for Platform Data.
@@ -28,9 +23,6 @@ public class PlatformDataUrlBuilder {
     private static final String SHIFT_HISTORY = "/v1/shifthistory";
     private static final String RPC_STAFF_DETAILS = "/v1/rpc/staffdetails";
     private static final String COMMENTS = "/v1/comment";
-    private static final String TEAM = "/v1/team";
-    private static final String RPC_TEAM_CHILDREN ="/v1/rpc/teamchildren";
-
 
     private PlatformDataBean platformDataBean;
 
@@ -61,60 +53,6 @@ public class PlatformDataUrlBuilder {
                 .toString();
     }
 
-    public String teamById(String teamId) {
-        return UriComponentsBuilder.newInstance()
-                .uri(platformDataBean.getUrl())
-                .path(TEAM)
-                .query("code=eq.{teamId}")
-                .buildAndExpand(Collections.singletonMap("teamId", teamId))
-                .toString();
-
-    }
-
-    public String teamByIds(String... teamIds) {
-        return UriComponentsBuilder.newInstance()
-                .uri(platformDataBean.getUrl())
-                .path(TEAM)
-                .query("code=in.({teamIds})")
-                .buildAndExpand(Collections.singletonMap("teamIds", teamIds))
-                .toString();
-
-    }
-
-    public String teamQuery(TeamQuery team) {
-        Map<String, Object> variables = new HashMap<>();
-        UriComponentsBuilder builder = UriComponentsBuilder.newInstance()
-                .uri(platformDataBean.getUrl())
-                .path(TEAM);
-
-        ofNullable(team.getName()).ifPresent(name -> {
-            variables.put("name", name);
-            builder.query("name=eq.{name}");
-        });
-
-        ofNullable(team.getId()).ifPresent(id -> {
-            variables.put("id", id);
-            builder.query("id=eq.{id}");
-        });
-
-        ofNullable(team.getNameLike()).ifPresent(nameLike -> {
-            variables.put("nameLike", nameLike);
-            builder.query("name=like.{nameLike}");
-        });
-        ofNullable(team.getIds()).ifPresent(ids -> {
-            List<String> idsForProcessing = Arrays.stream(ids).map(id -> "\"" + id + "\"").collect(Collectors.toList());
-            String idsToProcess = StringUtils.join(idsForProcessing, ",");
-            variables.put("ids", idsToProcess);
-            builder.query("id=in.({ids})");
-        });
-
-        return builder
-                .buildAndExpand(variables)
-                .toString();
-
-    }
-
-
     public String queryShiftByTeamId(String teamId) {
         return UriComponentsBuilder.newInstance()
                 .uri(platformDataBean.getUrl())
@@ -135,7 +73,6 @@ public class PlatformDataUrlBuilder {
 
     }
 
-
     public String getStaffUrl() {
         return UriComponentsBuilder.newInstance()
                 .uri(platformDataBean.getUrl())
@@ -143,15 +80,6 @@ public class PlatformDataUrlBuilder {
                 .build()
                 .toString();
     }
-
-    public String teamChildren() {
-        return UriComponentsBuilder.newInstance()
-                .uri(platformDataBean.getUrl())
-                .path(RPC_TEAM_CHILDREN)
-                .build()
-                .toString();
-    }
-
 
     public String getCommentsById(String taskId) {
         return UriComponentsBuilder

--- a/src/main/java/uk/gov/homeoffice/borders/workflow/RefDataUrlBuilder.java
+++ b/src/main/java/uk/gov/homeoffice/borders/workflow/RefDataUrlBuilder.java
@@ -1,17 +1,24 @@
 package uk.gov.homeoffice.borders.workflow;
 
 import lombok.AllArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.homeoffice.borders.workflow.config.RefDataBean;
+import uk.gov.homeoffice.borders.workflow.identity.TeamQuery;
 
 import java.util.Collections;
+import java.util.stream.Collectors;
+import java.util.*;
+
+import static java.util.Optional.ofNullable;
 
 @Component
 @AllArgsConstructor(onConstructor = @__(@Autowired))
 public class RefDataUrlBuilder {
     private static final String LOCATION = "/location"; // ref
+    private static final String TEAM = "/team";
 
     private RefDataBean refDataBean;
 
@@ -25,4 +32,71 @@ public class RefDataUrlBuilder {
                 .toString();
     }
 
+    public String teamByCode(String teamId) {
+        return UriComponentsBuilder.newInstance()
+                .uri(refDataBean.getUrl())
+                .path(TEAM)
+                .query("code=eq.{teamId}")
+                .buildAndExpand(Collections.singletonMap("teamId", teamId))
+                .toString();
+    }
+
+    public String teamByCodeIds(String... teamIds) {
+        return UriComponentsBuilder.newInstance()
+                .uri(refDataBean.getUrl())
+                .path(TEAM)
+                .query("code=in.({teamIds})")
+                .buildAndExpand(Collections.singletonMap("teamIds", teamIds))
+                .toString();
+    }
+
+    public String teamQuery(TeamQuery team) {
+        Map<String, Object> variables = new HashMap<>();
+        UriComponentsBuilder builder = UriComponentsBuilder.newInstance()
+                .uri(refDataBean.getUrl())
+                .path(TEAM);
+
+        ofNullable(team.getName()).ifPresent(name -> {
+            variables.put("name", name);
+            builder.query("name=eq.{name}");
+        });
+
+        ofNullable(team.getId()).ifPresent(id -> {
+            variables.put("id", id);
+            builder.query("id=eq.{id}");
+        });
+
+        ofNullable(team.getNameLike()).ifPresent(nameLike -> {
+            variables.put("nameLike", nameLike);
+            builder.query("name=like.{nameLike}");
+        });
+        ofNullable(team.getIds()).ifPresent(ids -> {
+            List<String> idsForProcessing = Arrays.stream(ids).map(id -> "\"" + id + "\"").collect(Collectors.toList());
+            String idsToProcess = StringUtils.join(idsForProcessing, ",");
+            variables.put("ids", idsToProcess);
+            builder.query("id=in.({ids})");
+        });
+
+        return builder
+                .buildAndExpand(variables)
+                .toString();
+    }
+
+    public String teamById(String teamId) {
+        return UriComponentsBuilder.newInstance()
+                .uri(refDataBean.getUrl())
+                .path(TEAM)
+                .query("id=eq.{teamId}")
+                .buildAndExpand(Collections.singletonMap("teamId", teamId))
+                .toString();
+    }
+
+    public String teamChildrenByParentTeamId(String parentTeamId) {
+        return UriComponentsBuilder.newInstance()
+                .uri(refDataBean.getUrl())
+                .path(TEAM)
+                .query("parentteamid=eq.{parentTeamId}")
+                .buildAndExpand(Collections.singletonMap("parentTeamId", parentTeamId))
+                .toString();
+    }
 }

--- a/src/main/java/uk/gov/homeoffice/borders/workflow/identity/IdentityConfig.java
+++ b/src/main/java/uk/gov/homeoffice/borders/workflow/identity/IdentityConfig.java
@@ -13,6 +13,7 @@ public class IdentityConfig {
 
     @Autowired
     private PlatformDataUrlBuilder platformDataUrlBuilder;
+    private RefDataUrlBuilder refDataUrlBuilder;
 
     @Autowired
     private RestTemplate restTemplate;
@@ -24,13 +25,13 @@ public class IdentityConfig {
 
     @Bean
     public UserService userService() {
-        return new UserService(restTemplate, platformDataUrlBuilder, teamService());
+        return new UserService(restTemplate, platformDataUrlBuilder, refDataUrlBuilder, teamService());
     }
 
 
     @Bean
     public TeamService teamService() {
-        return new TeamService(restTemplate, platformDataUrlBuilder);
+        return new TeamService(restTemplate, refDataUrlBuilder);
     }
 
     @Bean

--- a/src/main/java/uk/gov/homeoffice/borders/workflow/identity/TeamService.java
+++ b/src/main/java/uk/gov/homeoffice/borders/workflow/identity/TeamService.java
@@ -7,7 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
 import org.springframework.web.client.RestTemplate;
-import uk.gov.homeoffice.borders.workflow.PlatformDataUrlBuilder;
+import uk.gov.homeoffice.borders.workflow.RefDataUrlBuilder;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -18,13 +18,13 @@ import java.util.List;
 public class TeamService {
 
     private RestTemplate restTemplate;
-    private PlatformDataUrlBuilder platformDataUrlBuilder;
+    private RefDataUrlBuilder refDataUrlBuilder;
 
     public Team findById(String teamId) {
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.set("Accept", "application/json");
         HttpEntity httpEntity = new HttpEntity(httpHeaders);
-        ResponseEntity<List<Team>> response = restTemplate.exchange(platformDataUrlBuilder.teamById(teamId),
+        ResponseEntity<List<Team>> response = restTemplate.exchange(refDataUrlBuilder.teamByCode(teamId),
                 HttpMethod.GET, httpEntity, new ParameterizedTypeReference<List<Team>>() {});
         return response.getStatusCode().is2xxSuccessful() && !response.getBody().isEmpty() ? response.getBody().get(0) : null;
 
@@ -34,7 +34,7 @@ public class TeamService {
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.setContentType(MediaType.APPLICATION_JSON);
         List<Team> teams = restTemplate.exchange(
-                platformDataUrlBuilder.teamQuery(query),
+                refDataUrlBuilder.teamQuery(query),
                 HttpMethod.GET,
                 new HttpEntity<>(httpHeaders),
                 new ParameterizedTypeReference<List<Team>>() {

--- a/src/main/java/uk/gov/homeoffice/borders/workflow/task/TaskWebSocketConfig.java
+++ b/src/main/java/uk/gov/homeoffice/borders/workflow/task/TaskWebSocketConfig.java
@@ -20,7 +20,7 @@ import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.server.support.AbstractHandshakeHandler;
-import uk.gov.homeoffice.borders.workflow.PlatformDataUrlBuilder;
+import uk.gov.homeoffice.borders.workflow.RefDataUrlBuilder;
 import uk.gov.homeoffice.borders.workflow.security.SecurityConfig;
 
 import java.security.Principal;
@@ -38,8 +38,8 @@ public class TaskWebSocketConfig extends AbstractSessionWebSocketMessageBrokerCo
 
     @Bean
     public UserTaskEventListener userTaskEventListener(SimpMessagingTemplate simpMessagingTemplate,
-                                                       PlatformDataUrlBuilder platformDataUrlBuilder, RestTemplate restTemplate) {
-        return new UserTaskEventListener(simpMessagingTemplate, platformDataUrlBuilder, restTemplate);
+                                                       RefDataUrlBuilder refDataUrlBuilder, RestTemplate restTemplate) {
+        return new UserTaskEventListener(simpMessagingTemplate, refDataUrlBuilder, restTemplate);
     }
 
     @Override
@@ -51,7 +51,7 @@ public class TaskWebSocketConfig extends AbstractSessionWebSocketMessageBrokerCo
         te.setPoolSize(2);
         te.setThreadNamePrefix("wss-heartbeat-thread-");
         te.initialize();
-        
+
         config.setApplicationDestinationPrefixes("/ws");
         config.enableSimpleBroker("/topic", "/queue")
                 .setTaskScheduler(te)

--- a/src/main/java/uk/gov/homeoffice/borders/workflow/task/UserTaskEventListener.java
+++ b/src/main/java/uk/gov/homeoffice/borders/workflow/task/UserTaskEventListener.java
@@ -15,7 +15,7 @@ import org.springframework.http.MediaType;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.transaction.support.TransactionSynchronizationAdapter;
 import org.springframework.web.client.RestTemplate;
-import uk.gov.homeoffice.borders.workflow.PlatformDataUrlBuilder;
+import uk.gov.homeoffice.borders.workflow.RefDataUrlBuilder;
 import uk.gov.homeoffice.borders.workflow.identity.Team;
 
 import java.util.ArrayList;
@@ -33,7 +33,7 @@ import static org.springframework.transaction.support.TransactionSynchronization
 public class UserTaskEventListener extends ReactorTaskListener {
 
     private SimpMessagingTemplate messagingTemplate;
-    private PlatformDataUrlBuilder platformDataUrlBuilder;
+    private RefDataUrlBuilder refDataUrlBuilder;
     private RestTemplate restTemplate;
 
     @Override
@@ -61,7 +61,7 @@ public class UserTaskEventListener extends ReactorTaskListener {
                 httpHeaders.setContentType(MediaType.APPLICATION_JSON);
                 HttpEntity<?> entity = new HttpEntity<>(httpHeaders);
 
-                List<Team> response = restTemplate.exchange(platformDataUrlBuilder.teamByIds(teamCodes.toArray(new String[]{})),
+                List<Team> response = restTemplate.exchange(refDataUrlBuilder.teamByCodeIds(teamCodes.toArray(new String[]{})),
                         HttpMethod.GET, entity, new ParameterizedTypeReference<List<Team>>() {
                         }).getBody();
 

--- a/src/test/groovy/uk/gov/homeoffice/borders/workflow/identity/TeamServiceSpec.groovy
+++ b/src/test/groovy/uk/gov/homeoffice/borders/workflow/identity/TeamServiceSpec.groovy
@@ -5,8 +5,8 @@ import com.github.tomjankes.wiremock.WireMockGroovy
 import org.junit.Rule
 import org.springframework.web.client.RestTemplate
 import spock.lang.Specification
-import uk.gov.homeoffice.borders.workflow.PlatformDataUrlBuilder
-import uk.gov.homeoffice.borders.workflow.config.PlatformDataBean
+import uk.gov.homeoffice.borders.workflow.RefDataUrlBuilder
+import uk.gov.homeoffice.borders.workflow.config.RefDataBean
 
 class TeamServiceSpec extends Specification {
 
@@ -19,10 +19,10 @@ class TeamServiceSpec extends Specification {
     def teamService
 
     def setup() {
-        def platformDataBean = new PlatformDataBean()
-        platformDataBean.url=new URI("http://localhost:8182")
-        def platformDataUrlBuilder = new PlatformDataUrlBuilder(platformDataBean)
-        teamService = new TeamService(new RestTemplate(), platformDataUrlBuilder)
+        def refDataBean = new RefDataBean()
+        refDataBean.url=new URI("http://localhost:" + wmPort)
+        def refDataUrlBuilder = new RefDataUrlBuilder(refDataBean)
+        teamService = new TeamService(new RestTemplate(), refDataUrlBuilder)
     }
 
     def 'can find by id'() {
@@ -30,7 +30,7 @@ class TeamServiceSpec extends Specification {
         wireMockStub.stub {
             request {
                 method 'GET'
-                url '/v1/team?code=eq.code'
+                url '/team?code=eq.code'
             }
 
             response {
@@ -63,7 +63,7 @@ class TeamServiceSpec extends Specification {
         wireMockStub.stub {
             request {
                 method 'GET'
-                url '/v1/team?name=eq.name'
+                url '/team?name=eq.name'
             }
 
             response {

--- a/src/test/groovy/uk/gov/homeoffice/borders/workflow/identity/UserServiceSpec.groovy
+++ b/src/test/groovy/uk/gov/homeoffice/borders/workflow/identity/UserServiceSpec.groovy
@@ -7,30 +7,40 @@ import org.springframework.web.client.RestTemplate
 import spock.lang.Specification
 import uk.gov.homeoffice.borders.workflow.PlatformDataUrlBuilder
 import uk.gov.homeoffice.borders.workflow.config.PlatformDataBean
+import uk.gov.homeoffice.borders.workflow.RefDataUrlBuilder
+import uk.gov.homeoffice.borders.workflow.config.RefDataBean
 import uk.gov.homeoffice.borders.workflow.exception.InternalWorkflowException
 
 class UserServiceSpec extends Specification {
 
-    def wmPort = 8911
+    def platformDataPort = 8911
+    def refDataPort = 8912
 
     @Rule
-    WireMockRule wireMockRule = new WireMockRule(wmPort)
+    WireMockRule platformDataMockRule = new WireMockRule(platformDataPort)
 
-    def wireMockStub = new WireMockGroovy(wmPort)
+    @Rule
+    WireMockRule refDataMockRule = new WireMockRule(refDataPort)
+
+    def platformDataMockStub = new WireMockGroovy(platformDataPort)
+    def refDataMockStub = new WireMockGroovy(refDataPort)
     def userService
 
     def setup() {
         def platformDataBean = new PlatformDataBean()
-        platformDataBean.url = new URI("http://localhost:8911")
+        platformDataBean.url = new URI("http://localhost:" + platformDataPort)
         def platformDataUrlBuilder = new PlatformDataUrlBuilder(platformDataBean)
+        def refDataBean = new RefDataBean()
+        refDataBean.url = new URI("http://localhost:" + refDataPort)
+        def refDataUrlBuilder = new RefDataUrlBuilder(refDataBean)
         def teamService = Mock(TeamService)
-        userService = new UserService(new RestTemplate(), platformDataUrlBuilder, teamService)
+        userService = new UserService(new RestTemplate(), platformDataUrlBuilder, refDataUrlBuilder, teamService)
         userService.self = userService
     }
 
     def 'can find user by id'() {
         given:
-        wireMockStub.stub {
+        platformDataMockStub.stub {
             request {
                 method 'GET'
                 url '/v1/shift?email=eq.email'
@@ -55,7 +65,7 @@ class UserServiceSpec extends Specification {
 
         }
 
-        wireMockStub.stub {
+        platformDataMockStub.stub {
             request {
                 method 'POST'
                 url '/v1/rpc/staffdetails'
@@ -92,10 +102,10 @@ class UserServiceSpec extends Specification {
             }
         }
 
-        wireMockStub.stub {
+        refDataMockStub.stub {
             request {
-                method 'POST'
-                url '/v1/rpc/teamchildren'
+                method 'GET'
+                url '/team?parentteamid=eq.teamid'
 
             }
             response {
@@ -116,7 +126,29 @@ class UserServiceSpec extends Specification {
             }
         }
 
+        refDataMockStub.stub {
+            request {
+                method 'GET'
+                url '/team?id=eq.teamid'
 
+            }
+            response {
+                status: 200
+                body """
+                       [
+                          {
+                            "id": "teamid",
+                            "parentteamid": null,
+                            "name": "teamname",
+                            "code": "teamcode"
+                          }
+                        ]
+                     """
+                headers {
+                    "Content-Type" "application/json"
+                }
+            }
+        }
 
         when:
         def result = userService.findByUserId("email")
@@ -124,12 +156,11 @@ class UserServiceSpec extends Specification {
         then:
         result
         result.email == 'email'
-
     }
 
     def 'can find by team id'() {
         given:
-        wireMockStub.stub {
+        platformDataMockStub.stub {
             request {
                 method 'GET'
                 url '/v1/shift?teamid=eq.teamId'
@@ -154,7 +185,7 @@ class UserServiceSpec extends Specification {
 
         }
 
-        wireMockStub.stub {
+        platformDataMockStub.stub {
             request {
                 method 'GET'
                 url '/v1/staffview?staffid=in.(staffid)'
@@ -200,7 +231,7 @@ class UserServiceSpec extends Specification {
 
     def 'can find by location'() {
         given:
-        wireMockStub.stub {
+        platformDataMockStub.stub {
             request {
                 method 'GET'
                 url '/v1/shift?locationid=eq.locationId'
@@ -226,7 +257,7 @@ class UserServiceSpec extends Specification {
 
         }
 
-        wireMockStub.stub {
+        platformDataMockStub.stub {
             request {
                 method 'GET'
                 url '/v1/staffview?staffid=in.(staffid)'
@@ -283,7 +314,7 @@ class UserServiceSpec extends Specification {
 
     def 'can find by user id in query'() {
         given:
-        wireMockStub.stub {
+        platformDataMockStub.stub {
             request {
                 method 'GET'
                 url '/v1/shift?email=eq.email'
@@ -308,7 +339,7 @@ class UserServiceSpec extends Specification {
 
         }
 
-        wireMockStub.stub {
+        platformDataMockStub.stub {
             request {
                 method 'POST'
                 url '/v1/rpc/staffdetails'
@@ -342,10 +373,10 @@ class UserServiceSpec extends Specification {
             }
         }
 
-        wireMockStub.stub {
+        refDataMockStub.stub {
             request {
-                method 'POST'
-                url '/v1/rpc/teamchildren'
+                method 'GET'
+                url '/team?parentteamid=eq.teamid'
 
             }
             response {
@@ -366,6 +397,29 @@ class UserServiceSpec extends Specification {
             }
         }
 
+        refDataMockStub.stub {
+            request {
+                method 'GET'
+                url '/team?id=eq.teamid'
+
+            }
+            response {
+                status: 200
+                body """
+                       [
+                          {
+                            "id": "teamid",
+                            "parentteamid": null,
+                            "name": "teamname",
+                            "code": "teamcode"
+                          }
+                        ]
+                     """
+                headers {
+                    "Content-Type" "application/json"
+                }
+            }
+        }
 
         when:
         def query = new UserQuery()
@@ -380,7 +434,7 @@ class UserServiceSpec extends Specification {
 
     def 'no shift info returned if remote service throws Exception'() {
         given:
-        wireMockStub.stub {
+        platformDataMockStub.stub {
             request {
                 method 'GET'
                 url '/v1/shift?email=eq.email'
@@ -404,7 +458,7 @@ class UserServiceSpec extends Specification {
 
     def 'no shift info returned if remote service returns empty result'() {
         given:
-        wireMockStub.stub {
+        platformDataMockStub.stub {
             request {
                 method 'GET'
                 url '/v1/shift?email=eq.email'
@@ -429,7 +483,7 @@ class UserServiceSpec extends Specification {
 
     def 'exception thrown if staff details cannot be located'() {
         given:
-        wireMockStub.stub {
+        platformDataMockStub.stub {
             request {
                 method 'GET'
                 url '/v1/shift?email=eq.email'
@@ -454,7 +508,7 @@ class UserServiceSpec extends Specification {
 
         }
 
-        wireMockStub.stub {
+        platformDataMockStub.stub {
             request {
                 method 'POST'
                 url '/v1/rpc/staffdetails'

--- a/src/test/groovy/uk/gov/homeoffice/borders/workflow/task/UserTaskEventListenerSpec.groovy
+++ b/src/test/groovy/uk/gov/homeoffice/borders/workflow/task/UserTaskEventListenerSpec.groovy
@@ -10,8 +10,8 @@ import org.springframework.transaction.support.TransactionSynchronization
 import org.springframework.transaction.support.TransactionSynchronizationManager
 import org.springframework.web.client.RestTemplate
 import spock.lang.Specification
-import uk.gov.homeoffice.borders.workflow.PlatformDataUrlBuilder
-import uk.gov.homeoffice.borders.workflow.config.PlatformDataBean
+import uk.gov.homeoffice.borders.workflow.RefDataUrlBuilder
+import uk.gov.homeoffice.borders.workflow.config.RefDataBean
 
 class UserTaskEventListenerSpec extends Specification {
 
@@ -28,10 +28,10 @@ class UserTaskEventListenerSpec extends Specification {
 
     def setup() {
         TransactionSynchronizationManager.initSynchronization()
-        def platformDataBean = new PlatformDataBean()
-        platformDataBean.url=new URI("http://localhost:8900")
-        def platformDataUrlBuilder = new PlatformDataUrlBuilder(platformDataBean)
-        userTaskEventListener = new UserTaskEventListener(messagingTemplate, platformDataUrlBuilder, new RestTemplate())
+        def refDataBean = new RefDataBean()
+        refDataBean.url=new URI("http://localhost:" + wmPort)
+        def refDataUrlBuilder = new RefDataUrlBuilder(refDataBean)
+        userTaskEventListener = new UserTaskEventListener(messagingTemplate, refDataUrlBuilder, new RestTemplate())
     }
 
     def 'can notify on team task'() {
@@ -52,7 +52,7 @@ class UserTaskEventListenerSpec extends Specification {
         wireMockStub.stub {
             request {
                 method 'GET'
-                url '/v1/team?code=in.(teamA)'
+                url '/team?code=in.(teamA)'
             }
 
             response {


### PR DESCRIPTION
We've removed team data from the operational data so we need to change the engine to get team data from the ref data instead.

Existing url builder methods in `PlatformDataUrlBuilder` have been moved to `RefDataUrlBuilder`.

Two new methods (`teamById` and `teamChildrenByParentTeamId`) have been added to `RefDataUrlBuilder` which get the data previously returned by the `teamchildren` function.

The new methods are called from `UserService.getStaff()` and the data returned from each request are combined into a single array to replicate the previous data structure that was returned by the `teamchildren` function.