### PR TITLE
CO-1126 - Change the adelphi data type from integer to string

### DIFF
--- a/src/main/java/uk/gov/homeoffice/borders/workflow/identity/PlatformUser.java
+++ b/src/main/java/uk/gov/homeoffice/borders/workflow/identity/PlatformUser.java
@@ -30,7 +30,7 @@ public class PlatformUser implements org.camunda.bpm.engine.identity.User {
     private List<Qualification> qualifications = new ArrayList<>();
     private List<String> roles = new ArrayList<>();
 
-    private Integer adelphi;
+    private String adelphi;
     @JsonProperty("linemanagerid")
     private String lineManagerId;
 


### PR DESCRIPTION
The data type of the `adelphi` field has been changed in teh database from `integer` to `varchar(8)`.

This change changes the `adelphi` property of `PlatformUser` from `Integer` to `String` to match the database change.