### PR TITLE
COP-1952 - Integrate IS81/91 with Events at the Border

### DIFF
--- a/src/main/java/uk/gov/homeoffice/borders/workflow/process/ProcessStartDelegate.java
+++ b/src/main/java/uk/gov/homeoffice/borders/workflow/process/ProcessStartDelegate.java
@@ -19,14 +19,14 @@ public class ProcessStartDelegate implements JavaDelegate {
             String variableName = execution.getVariable("variableName").toString();
             String businessKey = execution.getVariable("businessKey").toString();
             String processKey = execution.getVariable("processKey").toString();
-            Object personKey = execution.getVariable("personKey");
+            Object is81Person = execution.getVariable("is81Person");
 
             HashMap variables = new HashMap();
             variables.put("type", "non-notification");
             variables.put(variableName, payload);
 
-            if (personKey != null) {
-                variables.put("personKey", personKey.toString());
+            if (is81Person != null) {
+                variables.put("is81Person", is81Person);
             }
 
             execution.getProcessEngineServices()

--- a/src/main/java/uk/gov/homeoffice/borders/workflow/process/ProcessStartDelegate.java
+++ b/src/main/java/uk/gov/homeoffice/borders/workflow/process/ProcessStartDelegate.java
@@ -5,6 +5,7 @@ import org.camunda.bpm.engine.delegate.BpmnError;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.JavaDelegate;
 import org.springframework.stereotype.Component;
+import java.util.HashMap;
 
 @Slf4j
 @Component
@@ -18,13 +19,21 @@ public class ProcessStartDelegate implements JavaDelegate {
             String variableName = execution.getVariable("variableName").toString();
             String businessKey = execution.getVariable("businessKey").toString();
             String processKey = execution.getVariable("processKey").toString();
+            Object personKey = execution.getVariable("personKey");
+
+            HashMap variables = new HashMap();
+            variables.put("type", "non-notification");
+            variables.put(variableName, payload);
+
+            if (personKey != null) {
+                variables.put("personKey", personKey.toString());
+            }
 
             execution.getProcessEngineServices()
                     .getRuntimeService()
                     .createProcessInstanceByKey(processKey)
                     .businessKey(businessKey)
-                    .setVariable("type", "non-notification")
-                    .setVariable(variableName, payload)
+                    .setVariables(variables)
                     .execute();
 
         } catch (Exception e) {


### PR DESCRIPTION
When we're starting a new IS81 process for each of the people in the E@B process that has the IS81 field selected, we need to know which person data from the E@B payload to use in each of these IS81 processes.

We have the same E@B data in each IS81 process and there is nothing in the IS81 process that can be used to reliably get the same person data each time.

This change updates `ProcessStartDelegate` to set a `personKey` value which gets passed to newly created workflows and can be used in the IS81 process to reliably get the person data from the E@B payload.

`personKey` is an integer value and is the position in the `people` array of the `peopleEaB` data of the person data that we need to use in the specific IS81 process.